### PR TITLE
Add goal cube and timer challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,16 @@
         height: 200px;
         background-color: rgba(0, 0, 0, 0.7); /* Semi-transparent black */
       }
+      #timer {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        background: rgba(0, 0, 0, 0.5);
+        color: white;
+        padding: 5px 10px;
+        border-radius: 4px;
+        font-family: sans-serif;
+      }
       #overlay {
         position: absolute;
         top: 0;
@@ -39,9 +49,11 @@
   </head>
   <body>
     <div id="miniMap"></div>
-    <div id="overlay" onclick="requestPointerLock()">
+    <div id="timer">Time: 0.0s</div>
+    <div id="overlay">
       <p>Click to capture the mouse</p>
       <p>Use WASD or Arrow keys to navigate</p>
+      <p>Find the golden cube to escape</p>
     </div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.160.1/three.min.js"></script>
     <script>
@@ -187,6 +199,18 @@
         });
       });
 
+      // Goal cube at maze exit
+      const goalGeometry = new THREE.BoxGeometry(unitSize, unitSize, unitSize);
+      const goalMaterial = new THREE.MeshPhongMaterial({ color: 0xffd700 });
+      const goal = new THREE.Mesh(goalGeometry, goalMaterial);
+      goal.position.set(
+        (mazeCols - 2) * unitSize - (mazeCols * unitSize) / 2,
+        unitSize / 2,
+        (mazeRows - 2) * unitSize - (mazeRows * unitSize) / 2
+      );
+      goal.castShadow = true;
+      scene.add(goal);
+
       camera.rotation.order = "YXZ"; // Set rotation order for camera
 
       // Lighting setup
@@ -196,6 +220,11 @@
       directionalLight.position.set(10, 20, 10);
       directionalLight.castShadow = true;
       scene.add(directionalLight);
+
+      // Timer and game state
+      let startTime = null;
+      let gameCompleted = false;
+      const timerEl = document.getElementById("timer");
 
       // Player movement setup
       let moveSpeed = 1;
@@ -253,6 +282,24 @@
           }
         }
         return false; // No collision
+      }
+
+      // Check if player reached the goal
+      function checkGoal() {
+        if (gameCompleted) return;
+        const distance = Math.hypot(
+          camera.position.x - goal.position.x,
+          camera.position.z - goal.position.z
+        );
+        if (distance < unitSize) {
+          gameCompleted = true;
+          const timeTaken = ((Date.now() - startTime) / 1000).toFixed(1);
+          const overlay = document.getElementById("overlay");
+          overlay.innerHTML = `<p>You found the golden cube!</p><p>Time: ${timeTaken}s</p><p>Click to play again</p>`;
+          overlay.style.display = "flex";
+          overlay.onclick = () => window.location.reload();
+          document.exitPointerLock();
+        }
       }
 
       // Handle key press events for player movement
@@ -370,13 +417,19 @@
         ) {
           overlay.style.display = "none";
           document.addEventListener("mousemove", updateCameraRotation, false);
+          if (!startTime) startTime = Date.now();
         } else {
-          overlay.style.display = "flex";
           document.removeEventListener(
             "mousemove",
             updateCameraRotation,
             false
           );
+          if (!gameCompleted) {
+            overlay.innerHTML =
+              "<p>Click to capture the mouse</p><p>Use WASD or Arrow keys to navigate</p><p>Find the golden cube to escape</p>";
+            overlay.style.display = "flex";
+            overlay.onclick = requestPointerLock;
+          }
         }
       }
 
@@ -393,10 +446,9 @@
       );
 
       // Initial overlay setup
-      document.getElementById("overlay").style.display = "flex";
-      document
-        .getElementById("overlay")
-        .addEventListener("click", requestPointerLock);
+      const overlayElement = document.getElementById("overlay");
+      overlayElement.style.display = "flex";
+      overlayElement.onclick = requestPointerLock;
 
       // Make renderer focusable to enable pointer lock
       renderer.domElement.setAttribute("tabindex", "0");
@@ -405,6 +457,10 @@
       function animate() {
         updateCameraPosition();
         createMiniMap();
+        if (startTime && !gameCompleted) {
+          timerEl.textContent = `Time: ${((Date.now() - startTime) / 1000).toFixed(1)}s`;
+        }
+        checkGoal();
         requestAnimationFrame(animate);
         renderer.render(scene, camera);
       }

--- a/readme.md
+++ b/readme.md
@@ -9,12 +9,14 @@ Try it here:
 
 1. Use W A S D keys or the arrow keys to navigate through the maze.
 2. Use the mouse to turn and look around.
+3. Find the golden cube to escape the maze as quickly as possible. A timer in the corner tracks how long you take.
 
 ## Features
 
 - 3D graphics using Three.js.
 - Randomly generated mazes for each playthrough.
 - Real-time rendering and movement.
+- Simple timer and goal cube for an extra challenge.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Add timer display and overlay instructions
- Introduce golden goal cube and win condition with time tracking
- Document new objective in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/maze/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c09b4641708330a41e87e1b4203035