### PR TITLE
Ensure goal cube spawns on open paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         do {
           gx = Math.floor(Math.random() * mazeCols);
           gy = Math.floor(Math.random() * mazeRows);
-        } while (maze[gy][gx] !== 0);
+        } while (maze[gy][gx] !== 1); // 1 indicates an open cell
         return { x: gx, y: gy };
       }
       const { x: goalX, y: goalY } = getRandomOpenCell();


### PR DESCRIPTION
## Summary
- Revert prior wall logic change
- Place goal cube only on maze cells without walls to avoid spawning inside bricks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c157255e148330a5d7cb424ddef83e